### PR TITLE
Add "Add to Sileo" and "Add to Installer" options

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,9 +18,13 @@
 	<div class="card">
 		<div class="card-body text-center">
 			<p>Welcome to Ramen's Repo</p>
-			<a class="btn btn-sm btn-primary" href="cydia://url/https://cydia.saurik.com/api/share#?source=https://ramen2x.github.io/"> Add to Cydia</a>
+			<a class="btn btn-sm btn-primary" href="sileo://source/https://ramen2x.github.io/">Add to Sileo</a>
+			&nbsp;&nbsp;
+			<a class="btn btn-sm btn-primary" href="cydia://url/https://cydia.saurik.com/api/share#?source=https://ramen2x.github.io/">Add to Cydia</a>
 			&nbsp;&nbsp;
 			<a class="btn btn-sm btn-primary" href="zbra://sources/add/https://ramen2x.github.io/">Add to Zebra</a>
+			&nbsp;&nbsp;
+			<a class="btn btn-sm btn-primary" href="installer://add/https://ramen2x.github.io/">Add to Installer</a>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
This PR is (mostly) self-explanatory - this adds in the "Add to Sileo" and "Add to Installer" options
(Note that I'm not overly involved with HTML stuff, wouldn't be too surprised if there's some HTML screw-up)

Only thing that might need explaining is the decision to put the Sileo option _before_ the Cydia option, which can be explained relatively simply:
- Cydia is largely expected to be dead with iOS 15, with it requiring a massive rewrite effort to work around SSV (not to mention the other 15.x changes), with a jailbreak coming at some point here in the somewhat near-ish future, this is a preemptive change more than anything else
- Most people will likely be using Sileo (or another package manager besides Cydia) for multiple reasons (such as Sileo being included in jailbreaks, Havoc (think of it as Packix 2) dropping paid package support with Cydia, Cydia generally tending to be viewed as "slower" (which is very valid), and a bunch of other reasons which would take too long to list)